### PR TITLE
Fix mistaken comment about enabling synchronization

### DIFF
--- a/demo/sinchronized.html
+++ b/demo/sinchronized.html
@@ -17,7 +17,7 @@
         window.zoomTiger = svgPanZoom('#demo-tiger', {
           zoomEnabled: true,
           controlIconsEnabled: true,
-          // Uncomment this in order to get Y asis synchronized pan
+          // Set y to true in order to get Y asis synchronized pan
           beforePan: function(oldP, newP) {return {y:false}},
         });
 


### PR DESCRIPTION
The comment saying to uncomment the following line is in error.  What the user actually needs to do is to set y to true.  This comment fixes that mistake so the user can enable synchronization.