### PR TITLE
Expose SVG element in the public instance

### DIFF
--- a/src/svg-pan-zoom.js
+++ b/src/svg-pan-zoom.js
@@ -730,6 +730,9 @@ SvgPanZoom.prototype.getPublicInstance = function() {
   // Create cache
   if (!this.publicInstance) {
     this.publicInstance = this.pi = {
+      // SVG Element
+      svg: that.svg,
+
       // Pan
       enablePan: function() {
         that.options.panEnabled = true;


### PR DESCRIPTION
This patch allows the user to get to the svg element from the originating html page.  It allows the user to change the SVG programmatically based on zoom-- for example, layering multiple SVGs and showing/hiding them based on zoom level.