### PR TITLE
Update link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Pan and zoom the SVG tiger on github pages:
 How To Use
 ----------
 
-Reference the [svg-pan-zoom.js file](http://ariutta.github.io/svg-pan-zoom/dist/svg-pan-zoom.min.js) from your HTML document. Then call the init method:
+Reference the [svg-pan-zoom.js file](https://github.com/bumbu/svg-pan-zoom/blob/master/dist/svg-pan-zoom.min.js) from your HTML document. Then call the init method:
 
 ```js
 var panZoomTiger = svgPanZoom('#demo-tiger');


### PR DESCRIPTION
I would have linked to https://bumbu.me/svg-pan-zoom/dist/svg-pan-zoom.min.js, but that file is outdated (3.6.0 instead of latest 3.6.1).