### PR TITLE
Add missing `x`, `y` fields to the typescript `Sizes` type declaration.

### DIFF
--- a/dist/svg-pan-zoom.d.ts
+++ b/dist/svg-pan-zoom.d.ts
@@ -82,6 +82,8 @@ declare namespace SvgPanZoom {
     height: number;
     realZoom: number;
     viewBox: {
+      x: number;
+      y: number;
       width: number;
       height: number;
     };


### PR DESCRIPTION
As documented in [public-api](https://github.com/bumbu/svg-pan-zoom?tab=readme-ov-file#public-api), the `getSizes()` method returns a `viewBox` that contains both `width`/`height` as well as `x`/`y` fields; however the Typescript type only contain the former.

This PR adds the missing fields.